### PR TITLE
Be nice and return response from do_request

### DIFF
--- a/lib/webmachine/test/session.rb
+++ b/lib/webmachine/test/session.rb
@@ -74,6 +74,7 @@ module Webmachine
         @res = Webmachine::Response.new
 
         @app.dispatcher.dispatch(@req, @res)
+        return @res
       end
 
       def add_query_params(uri, params)


### PR DESCRIPTION
This change is useful when you want to assert on response returned by particular test method rather than accessing last response cached in instance variable.

It seems reasonable to do that when you wrap test methods into test client and build your suite around it, i.e:

``` ruby
 def test_get_a_single_notice
   client.get(notice_path, params: {id: notice.id}) do |response|
     assert_equal 200, response.code
   end
 end

```
