### PR TITLE
Make session compatible with 'trace?'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .rvmrc
 Gemfile.lock
 pkg/*
+.idea/

--- a/lib/webmachine/test/session.rb
+++ b/lib/webmachine/test/session.rb
@@ -52,9 +52,8 @@ module Webmachine
       end
 
       def do_request(method, uri, options)
+        uri = "http://localhost#{uri}" unless uri =~ /^http:\/\//
         uri = URI.parse(uri)
-        uri.scheme ||= 'http'
-        uri.host ||= 'localhost'
 
         add_query_params(uri, options[:params])
 

--- a/spec/fixtures/test_resource.rb
+++ b/spec/fixtures/test_resource.rb
@@ -1,5 +1,3 @@
-require 'webmachine'
-
 class TestResource < Webmachine::Resource
   def content_types_provided
     [['text/plain', :to_text]]

--- a/spec/fixtures/traceable_resource.rb
+++ b/spec/fixtures/traceable_resource.rb
@@ -1,0 +1,9 @@
+class TraceableResource < Webmachine::Resource
+  def trace?
+    true
+  end
+
+  def to_html
+    "<html><head><title>Hi</title><body><p>html_hi</p></body></html>"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,18 @@ require 'bundler/setup'
 
 require 'webmachine/application'
 require 'webmachine/test'
+require 'webmachine'
+
 require 'fixtures/test_resource'
+require 'fixtures/traceable_resource'
 
 module WebmachineTestApplication
   def app
-    @app ||= Webmachine::Application.new.tap do |test_app|
-      test_app.add_route(['*'], TestResource)
+    @app ||= Webmachine::Application.new do |test_app|
+      test_app.routes do
+        add ['traceme'], TraceableResource
+        add ['*'], TestResource
+      end
     end
   end
 end

--- a/spec/webmachine/test/session_spec.rb
+++ b/spec/webmachine/test/session_spec.rb
@@ -17,15 +17,29 @@ describe Webmachine::Test::Session do
   end
 
   describe "#response" do
-    it "returns the Webmachine::Response object" do
-      get '/'
-      response.should be_a(Webmachine::Response)
-    end
-
     context "without a request" do
       it "raises an exception" do
         expect { response }.to raise_error(Webmachine::Test::Error)
       end
+    end
+
+    context "with an untraceable resource" do
+      before { get '/' }
+
+      subject { response }
+
+      it { should be_a(Webmachine::Response) }
+      its(:code) { should eql(200) }
+      its(:body) { should eql('OK') }
+    end
+
+    context "with a traceable resource" do
+      before { get '/traceme' }
+
+      subject { response }
+
+      its(:code) { should eql(200) }
+      its(:body) { should include('html_hi') }
     end
   end
 
@@ -50,12 +64,12 @@ describe Webmachine::Test::Session do
     context "with an incomplete URI" do
       it "sets the correct host header" do
         send verb, '/foo'
-        request.headers['Host'].should == 'localhost'
+        request.headers['Host'].should == 'localhost:80'
       end
     end
 
     it "accepts query parameters in the path" do
-      send verb,'/?lang=en&foo=bar'
+      send verb, '/?lang=en&foo=bar'
       request.query['lang'].should == 'en'
       request.query['foo'].should == 'bar'
     end
@@ -73,7 +87,7 @@ describe Webmachine::Test::Session do
     end
 
     it "encodes the query key and value." do
-      send verb, '/', :params => { "foo=" => "bar=" }
+      send verb, '/', :params => {"foo=" => "bar="}
       request.uri.query.should == "foo%3D=bar%3D"
     end
 


### PR DESCRIPTION
A putative request that fixes #10 and makes `Session` compatible with `trace?`
