### PR TITLE
Added support for session cookies

### DIFF
--- a/lib/webmachine/test.rb
+++ b/lib/webmachine/test.rb
@@ -14,7 +14,7 @@ module Webmachine
       @session ||= Webmachine::Test::Session.new(app)
     end
 
-    def_delegators :current_session, :request, :header, :headers, :cookie, :cookies, :body, :response,
+    def_delegators :current_session, :request, :header, :headers, :cookie, :session_cookies, :body, :response,
                                      :get, :post, :put, :patch, :delete,
                                      :options, :head
   end

--- a/lib/webmachine/test.rb
+++ b/lib/webmachine/test.rb
@@ -14,7 +14,7 @@ module Webmachine
       @session ||= Webmachine::Test::Session.new(app)
     end
 
-    def_delegators :current_session, :request, :header, :headers, :body, :response,
+    def_delegators :current_session, :request, :header, :headers, :cookie, :cookies, :body, :response,
                                      :get, :post, :put, :patch, :delete,
                                      :options, :head
   end

--- a/lib/webmachine/test/session.rb
+++ b/lib/webmachine/test/session.rb
@@ -10,6 +10,7 @@ module Webmachine
 
       def initialize(app)
         @headers = Webmachine::Headers.new
+        @session_cookies = {}
         @body = nil
         @req = nil
         @res = nil
@@ -29,6 +30,10 @@ module Webmachine
       # Set a single header for the next request.
       def header(name, value)
         @headers[name] = value
+      end
+      
+      def cookie(name, value)
+        @session_cookies[name] = value
       end
 
       # Set the request body.
@@ -56,11 +61,14 @@ module Webmachine
         add_query_params(uri, options[:params])
 
         # Set some default headers and merge the provided ones.
-        @headers['Host'] = [uri.host, uri.port].compact.join(':') unless @headers['Host']
-        @headers['Accept'] = '*/*' unless @headers['Accept']
+        @headers['Host'] ||= [uri.host, uri.port].compact.join(':')
+        @headers['Accept'] ||= '*/*'
+        @headers['Origin'] ||= @headers['Host']
+        add_cookies
 
         options[:headers] ||= {}
         options[:headers].each { |k, v| @headers[k] = v }
+
 
         @body ||= options[:body]
 
@@ -68,7 +76,35 @@ module Webmachine
         @res = Webmachine::Response.new
 
         @app.dispatcher.dispatch(@req, @res)
+        update_session_cookies
         return @res
+      end
+      def update_session_cookies
+        if  @res.headers['Set-Cookie']
+          @res.headers['Set-Cookie'].reduce(@session_cookies) do |cookies, c| 
+            cookie_info = c.split(';')
+            kv = Webmachine::Cookie.parse(cookie_info.shift)
+            cname = kv.keys.first
+            cval = kv.values.first
+            cookie = cookie_info.map(&:strip).reduce({value: cval}) do |cookie, part|
+              case part
+              when 'Secure'
+                cookie[:secure] = true
+              when 'HttpOnly'
+                cookie[:http_only] = true
+              when /Expires=(?<date>.*)/
+                cookie[:expires] = Time.parse($~[:date])
+              end
+              cookie
+            end
+            if cookie[:value].nil? or (cookie[:expires] and cookie[:expires] < Time.now)
+              cookies.delete cname
+            else
+              cookies.merge!({cname => cval})
+            end
+            cookies
+          end
+        end
       end
 
       def add_query_params(uri, params)
@@ -80,6 +116,13 @@ module Webmachine
 
           uri.query = uri.query ? [uri.query, q].join('&') : q
         end
+      end
+      def add_cookies
+        as_strings = @session_cookies.map do |k,v|
+          "#{k}=#{v}"
+        end
+        cookies = as_strings.join("; ")
+        @headers['Cookie'] = cookies unless cookies.empty?
       end
     end
   end

--- a/lib/webmachine/test/session.rb
+++ b/lib/webmachine/test/session.rb
@@ -35,6 +35,9 @@ module Webmachine
       def cookie(name, value)
         @session_cookies[name] = value
       end
+      def session_cookies
+        @session_cookies
+      end
 
       # Set the request body.
       def body(value)

--- a/spec/fixtures/test_resource.rb
+++ b/spec/fixtures/test_resource.rb
@@ -4,6 +4,7 @@ class TestResource < Webmachine::Resource
   end
 
   def to_text
+    response.set_cookie 'TEST', 'VALUE'
     'OK'
   end
 end

--- a/spec/webmachine/test/session_spec.rb
+++ b/spec/webmachine/test/session_spec.rb
@@ -163,5 +163,9 @@ describe Webmachine::Test::Session do
       get '/'
       request.headers['COOKIE'].should eq('TEST=VALUE')
     end
+    it "shows available session cookies" do
+      get '/'
+      session_cookies['TEST'].should eq('VALUE')
+    end
   end
 end

--- a/spec/webmachine/test/session_spec.rb
+++ b/spec/webmachine/test/session_spec.rb
@@ -151,4 +151,17 @@ describe Webmachine::Test::Session do
       request.body.should be_nil
     end
   end
+  describe "#cookie" do
+    it "sets a cookie" do
+      cookie('SOME_COOKIE', 'VALUE')
+      get '/'
+      request.headers['COOKIE'].should eq('SOME_COOKIE=VALUE')
+    end
+    it "forwards cookies sent by the server (like a browser)" do
+      get '/'
+      request.headers['COOKIE'].should be_nil
+      get '/'
+      request.headers['COOKIE'].should eq('TEST=VALUE')
+    end
+  end
 end


### PR DESCRIPTION
This pull request simplifies the process of setting cookies on the request, and adds the ability for the test framework to store cookies set by the server and forward them on (acting like a browser). 